### PR TITLE
[Fix: 리포트 결과 내보내기 페이지] 

### DIFF
--- a/src/app/(with-layout)/layout.tsx
+++ b/src/app/(with-layout)/layout.tsx
@@ -13,23 +13,25 @@ export default async function Layout({
 
   return (
     <>
-      <div className="print:hidden">
+      <div className="sticky top-0 z-50 h-16 bg-white/80 backdrop-blur print:hidden">
         <SignHeader isLoggedIn={isLoggedIn} />
       </div>
 
       {isLoggedIn ? (
-        <div className="flex h-screen flex-col md:flex-row md:overflow-hidden print:block print:h-auto">
+        <div className="flex h-[calc(100vh-4rem)] flex-col overflow-hidden md:flex-row print:block print:h-auto print:overflow-visible">
           <div className="w-full flex-none md:w-64 print:hidden">
             <SideNav />
           </div>
-          <main className="flex-1 overflow-y-auto md:px-12 md:py-4 md:pb-0 print:w-full print:overflow-visible print:p-0">
+          <main className="flex-1 overflow-y-auto md:px-12 md:py-4 md:pb-0 print:overflow-visible">
             {children}
           </main>
         </div>
       ) : (
-        <main className="mx-auto max-w-screen-xl px-6 pt-2 pb-0 print:max-w-full print:p-0">
-          {children}
-        </main>
+        <div className="h-[calc(100vh-4rem)] print:h-auto">
+          <main className="mx-auto h-full max-w-screen-xl overflow-y-auto px-6 pt-2 pb-0 print:h-auto print:overflow-visible">
+            {children}
+          </main>
+        </div>
       )}
     </>
   );

--- a/src/app/ui/report-view/aside-area/aside-section.tsx
+++ b/src/app/ui/report-view/aside-area/aside-section.tsx
@@ -7,7 +7,7 @@ interface AsideSectionProps {
 
 function AsideSection({ commits }: AsideSectionProps) {
   return (
-    <aside className="flex min-w-0 flex-col rounded-lg border border-gray-200 bg-white p-4 shadow-sm lg:sticky lg:top-8 lg:h-[calc(100vh-4rem)] lg:basis-[30%] lg:overflow-y-auto print:hidden">
+    <aside className="flex min-w-0 flex-col overflow-y-auto rounded-lg border border-gray-200 bg-white p-4 shadow-sm lg:sticky lg:top-8 lg:max-h-[calc(100vh-6rem)] lg:basis-[30%] lg:self-start print:hidden">
       <section aria-labelledby="commit-list-title">
         <CommitList commits={commits} />
       </section>


### PR DESCRIPTION
## 📝 요약(Summary)
report-view 페이지에서 로그인 상태일 때
페이지 전체 스크롤이 되지 않거나 헤더의 sticky가 동작하지 않는 문제를 수정했습니다.
(Export 기능 적용 이후 레이아웃 구조에 overflow/h-screen 속성이 충돌한 것이 원인이었습니다.)

레이아웃 및 리포트 뷰 구조 수정으로
AsideSection의 sticky 및 내부 스크롤 동작 문제를 해결했습니다.

<br><br>

## ☑️ Task
- [x] 레이아웃 구조 재정비
- [x] overflow-hidden, h-screen 속성 충돌 제거
- [x] SignHeader sticky 동작 복원 (sticky top-0 유지)
- [x] AsideSection 구조 개선
- [x] sticky와 내부 스크롤 영역을 분리
- [x] 콘텐츠가 화면을 넘어가도 자연스럽게 스크롤 가능하도록 조정
- [x] 로그인/비로그인 상태 모두 동일하게 동작하도록 통일

<br><br>

## 📸 스크린샷 (선택)

![수정 후 동작 모습](https://github.com/user-attachments/assets/db8243fa-991a-4234-809a-0898eedfc69b)

<br><br>

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

<br><br>

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
